### PR TITLE
add a fixture to reset the config before every test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,14 @@
+import pytest
+
+import approvaltests
+
 pytest_plugins = 'pytester'
+
+_DEFAULT_REPORTER = approvaltests.get_default_reporter()
+
+
+@pytest.fixture(autouse=True)
+def reset_approvaltests_config(request):
+    approvaltests.set_default_reporter(_DEFAULT_REPORTER)
+    for option_name in [o for o in vars(request.config.option) if "approvaltests" in o]:
+        setattr(request.config.option, option_name, None)


### PR DESCRIPTION
This ensures that changes to the thread local default reporter object and command line options will be set to their defaults before each test function execution.

## But it's not small!

yes it is :)